### PR TITLE
Update command prefixes from / to . in documentation and error messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ This is a **Meteor Client addon** that bridges the **Model Context Protocol (MCP
 - ✅ **StarScript Integration**: Dynamic tool registration, argument conversion, result handling
 - ✅ **Async Execution**: Zero-blocking MCP calls via background threads (60+ FPS guaranteed)
 - ✅ **Gemini AI Integration**: Multi-turn conversations with automatic MCP tool calling
-- ✅ **Chat Commands**: Dynamic `/server:tool`, `/gemini`, and `/gemini-mcp` with help system
+- ✅ **Chat Commands**: Dynamic `.server:tool`, `.gemini`, and `.gemini-mcp` with help system
 - ✅ **GUI System**: Complete configuration screens for servers, tools, and Gemini settings
 - ✅ **Persistence**: NBT-based storage for all configurations
 
@@ -143,9 +143,9 @@ MCPToolExecutor.execute()
 
 #### Command Integration (`commands/`)
 - **`CommandUtils.java`**: Shared key=value/JSON parser plus chat output helpers for tool results
-- **`MCPToolCommand.java`**: Dynamic Brigadier command per MCP tool (`/server:tool …`) with help + suggestions
-- **`GeminiCommand.java`**: `/gemini "prompt"` chat command with async execution and per-player cooldown
-- **`GeminiMCPCommand.java`**: `/gemini-mcp "prompt"` with automatic MCP tool discovery and usage reporting
+- **`MCPToolCommand.java`**: Dynamic Brigadier command per MCP tool (`.server:tool …`) with help + suggestions
+- **`GeminiCommand.java`**: `.gemini "prompt"` chat command with async execution and per-player cooldown
+- **`GeminiMCPCommand.java`**: `.gemini-mcp "prompt"` with automatic MCP tool discovery and usage reporting
 
 `MCPServers` mirrors StarScript registration by adding/removing `MCPToolCommand` instances whenever servers connect or disconnect, refreshing the Brigadier dispatcher to keep the chat tree accurate.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,7 +7,7 @@
 **Core Purpose:**
 1.  **Connect:** Link Minecraft to external MCP servers (local or remote).
 2.  **Expose:** Make MCP tools available as StarScript functions (`{server.tool()}`).
-3.  **Automate:** Use Gemini AI to intelligently orchestrate these tools via natural language (`/gemini-mcp`).
+3.  **Automate:** Use Gemini AI to intelligently orchestrate these tools via natural language (`.gemini-mcp`).
 
 ## 2. Architecture & Data Flow
 
@@ -42,9 +42,9 @@ graph TD
     MTE -->|Direct Call| MCPServer
 ```
 
-### 2.2 The "Enhanced" Gemini Flow (`/gemini-mcp`)
+### 2.2 The "Enhanced" Gemini Flow (`.gemini-mcp`)
 
-When a user executes `/gemini-mcp "Get weather in Tokyo"`, the following sequence occurs in `GeminiExecutor`:
+When a user executes `.gemini-mcp "Get weather in Tokyo"`, the following sequence occurs in `GeminiExecutor`:
 
 1.  **Tool Collection:** The system retrieves all connected MCP servers and converts their tools into Gemini-compatible `FunctionDeclaration` objects using `MCPToGeminiBridge`.
 2.  **Initial Request:** The prompt and tool definitions are sent to the Gemini API.
@@ -103,9 +103,9 @@ Once connected, tools are available globally:
 *   `{weather.get_forecast("London", 3)}`
 
 ### 4.3 Chat Commands
-*   `/gemini "Explain quantum physics"` (Simple text)
-*   `/gemini-mcp "Check the weather in London and tell me if I need an umbrella"` (Uses connected tools)
-*   `/time:get_current_time timezone="UTC"` (Auto-generated command for specific tool)
+*   `.gemini "Explain quantum physics"` (Simple text)
+*   `.gemini-mcp "Check the weather in London and tell me if I need an umbrella"` (Uses connected tools)
+*   `.time:get_current_time timezone="UTC"` (Auto-generated command for specific tool)
 
 ## 5. Development
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@
     </tr>
     <tr>
       <td><strong>Dynamic Chat Commands</strong></td>
-      <td>Automatically registered <code>/serverName:toolName</code> commands with help and tab completion</td>
+      <td>Automatically registered <code>.serverName:toolName</code> commands with help and tab completion</td>
     </tr>
     <tr>
       <td><strong>Gemini AI (Optional)</strong></td>
-      <td>Direct requests with <code>/gemini</code> or MCP-enhanced requests with <code>/gemini-mcp</code></td>
+      <td>Direct requests with <code>.gemini</code> or MCP-enhanced requests with <code>.gemini-mcp</code></td>
     </tr>
   </table>
 
@@ -79,7 +79,7 @@
 
   <table>
     <tr><td><code># Time queries</code></td></tr>
-    <tr><td><code>/time:get_current_time timezone="UTC"</code></td></tr>
+    <tr><td><code>.time:get_current_time timezone="UTC"</code></td></tr>
   </table>
 
   <h2>Gemini AI Integration (Optional)</h2>
@@ -97,11 +97,11 @@
 
   <table>
     <tr><td><strong>Simple prompts:</strong></td></tr>
-    <tr><td><code>/gemini "Explain what StarScript is"</code></td></tr>
+    <tr><td><code>.gemini "Explain what StarScript is"</code></td></tr>
     <tr><td><code>{gemini("What is the current Minecraft version?")}</code></td></tr>
     <tr><td><strong>MCP-enhanced prompts:</strong></td></tr>
-    <tr><td><code>/gemini-mcp "Read my config.json and explain each setting"</code></td></tr>
+    <tr><td><code>.gemini-mcp "Read my config.json and explain each setting"</code></td></tr>
     <tr><td><code>{gemini_mcp("Get the current time in Tokyo")}</code></td></tr>
-    <tr><td>The <code>/gemini-mcp</code> command allows Gemini to automatically discover and call any connected MCP tool. Tool usage is reported in the response.</td></tr>
+    <tr><td>The <code>.gemini-mcp</code> command allows Gemini to automatically discover and call any connected MCP tool. Tool usage is reported in the response.</td></tr>
   </table>
 </div>

--- a/ai_specs/COMMAND_INTEGRATION_SPEC.md
+++ b/ai_specs/COMMAND_INTEGRATION_SPEC.md
@@ -4,9 +4,9 @@
 
 Add Minecraft chat command support for direct MCP tool invocation and Gemini AI interactions. This phase builds on the completed Gemini integration (Phase 2) and provides users with command-line access to:
 
-1. **Dynamic MCP Tool Commands**: Invoke any connected MCP server's tools via `/server:tool args`
-2. **Gemini Simple Command**: Quick AI queries via `/gemini "prompt"`
-3. **Gemini MCP Command**: AI queries with automatic MCP tool access via `/gemini-mcp "prompt"`
+1. **Dynamic MCP Tool Commands**: Invoke any connected MCP server's tools via `.server:tool args`
+2. **Gemini Simple Command**: Quick AI queries via `.gemini "prompt"`
+3. **Gemini MCP Command**: AI queries with automatic MCP tool access via `.gemini-mcp "prompt"`
 
 **Design Philosophy**: Commands provide an alternative to StarScript expressions, offering:
 - Direct tool execution without StarScript syntax
@@ -20,7 +20,7 @@ Add Minecraft chat command support for direct MCP tool invocation and Gemini AI 
 
 ### 1.1 MCP Tool Commands
 
-**Pattern**: `/server_name:tool_name [arguments]`
+**Pattern**: `.server_name:tool_name [arguments]`
 
 **Rationale**:
 - **Colon separator**: Clear namespace delimiter (inspired by Minecraft's `namespace:id` pattern)
@@ -58,16 +58,16 @@ Add Minecraft chat command support for direct MCP tool invocation and Gemini AI 
 
 ### 1.2 Gemini Simple Command
 
-**Pattern**: `/gemini "prompt"`
+**Pattern**: `.gemini "prompt"`
 
 **Purpose**: Quick AI queries without MCP tool access
 
 **Examples**:
 
 ```bash
-/gemini "What is the capital of France?"
-/gemini "Explain quantum computing in simple terms"
-/gemini "Write a haiku about Minecraft"
+.gemini "What is the capital of France?"
+.gemini "Explain quantum computing in simple terms"
+.gemini "Write a haiku about Minecraft"
 ```
 
 **Behavior**:
@@ -85,7 +85,7 @@ Add Minecraft chat command support for direct MCP tool invocation and Gemini AI 
 
 ### 1.3 Gemini MCP Command
 
-**Pattern**: `/gemini-mcp "prompt"`
+**Pattern**: `.gemini-mcp "prompt"`
 
 **Purpose**: AI queries with automatic access to ALL connected MCP server tools
 
@@ -93,19 +93,19 @@ Add Minecraft chat command support for direct MCP tool invocation and Gemini AI 
 
 ```bash
 # Single tool usage
-/gemini-mcp "What's the weather in Tokyo?"
+.gemini-mcp "What's the weather in Tokyo?"
 # → Gemini calls weather:get_forecast(location="Tokyo")
 # → Returns formatted weather data
 
 # Multi-tool workflow
-/gemini-mcp "If it's sunny in London tomorrow, schedule a picnic at 2pm"
+.gemini-mcp "If it's sunny in London tomorrow, schedule a picnic at 2pm"
 # → Gemini calls weather:get_forecast(location="London", days=1)
 # → Evaluates condition
 # → Calls calendar:schedule_meeting(time="14:00", topic="Picnic")
 # → Returns confirmation message
 
 # Data analysis
-/gemini-mcp "Summarize our sales data from last month"
+.gemini-mcp "Summarize our sales data from last month"
 # → Gemini calls database:query_sales(period="last_month")
 # → Analyzes results
 # → Returns formatted summary
@@ -802,7 +802,7 @@ public void onInitialize() {
 
 **Enhancement**: Add help subcommand for MCP tool commands
 
-**Pattern**: `/server:tool help`
+**Pattern**: `.server:tool help`
 
 **Implementation** (in `MCPToolCommand.build()`):
 
@@ -979,7 +979,7 @@ private static Object coerceValue(String value, JsonNode paramSchema) {
 
 ### 5.3 Gemini API Rate Limiting
 
-**Scenario**: User spams `/gemini` commands, hits API rate limit
+**Scenario**: User spams `.gemini` commands, hits API rate limit
 
 **Handling**: Implement client-side cooldown
 
@@ -1048,13 +1048,13 @@ MeteorExecutor.execute(() -> {
 - [ ] Try running disconnected command (should fail gracefully)
 
 **Gemini Commands**:
-- [ ] Run `/gemini "What is 2+2?"` (simple query)
-- [ ] Run `/gemini` without arguments (should show error)
-- [ ] Run `/gemini` without API key configured (should show config prompt)
-- [ ] Spam `/gemini` commands (verify cooldown works)
+- [ ] Run `.gemini "What is 2+2?"` (simple query)
+- [ ] Run `.gemini` without arguments (should show error)
+- [ ] Run `.gemini` without API key configured (should show config prompt)
+- [ ] Spam `.gemini` commands (verify cooldown works)
 
 **Gemini MCP Commands**:
-- [ ] Connect weather server, run `/gemini-mcp "What's the weather in Tokyo?"`
+- [ ] Connect weather server, run `.gemini-mcp "What's the weather in Tokyo?"`
 - [ ] Verify Gemini calls `weather:get_forecast` automatically
 - [ ] Run with multiple servers connected (weather + calendar)
 - [ ] Run complex prompt requiring multiple tool calls
@@ -1233,15 +1233,15 @@ src/main/java/com/cope/meteormcp/
 ### Gemini Simple Queries
 
 ```bash
-/gemini "What is the capital of France?"
+.gemini "What is the capital of France?"
 > [Gemini] The capital of France is Paris.
 
-/gemini "Explain quantum entanglement"
+.gemini "Explain quantum entanglement"
 > [Gemini] Quantum entanglement is a phenomenon where two or more
 > particles become interconnected in such a way that the state of
 > one particle instantly influences the state of the other...
 
-/gemini "Write a haiku about Minecraft"
+.gemini "Write a haiku about Minecraft"
 > [Gemini] Blocks stack high above
 > Creepers lurk in darkened caves
 > Build and mine, survive
@@ -1253,14 +1253,14 @@ src/main/java/com/cope/meteormcp/
 
 ```bash
 # Single tool call
-/gemini-mcp "What's the weather like in London?"
+.gemini-mcp "What's the weather like in London?"
 > [Gemini MCP] Querying Gemini with 1 MCP servers...
 > [Gemini MCP] The weather in London is currently cloudy with a
 > temperature of 15°C and light rain expected later today.
 > Tools used: weather:get_forecast
 
 # Multi-tool workflow
-/gemini-mcp "Check if it's sunny in Paris tomorrow, and if so, schedule a picnic at 2pm"
+.gemini-mcp "Check if it's sunny in Paris tomorrow, and if so, schedule a picnic at 2pm"
 > [Gemini MCP] Querying Gemini with 2 MCP servers...
 > [Gemini MCP] Good news! The forecast for Paris tomorrow shows sunny
 > weather with temperatures around 22°C. I've scheduled a picnic event
@@ -1268,7 +1268,7 @@ src/main/java/com/cope/meteormcp/
 > Tools used: weather:get_forecast, calendar:schedule_meeting
 
 # Data analysis
-/gemini-mcp "What were our top 3 products by sales last month?"
+.gemini-mcp "What were our top 3 products by sales last month?"
 > [Gemini MCP] Querying Gemini with 1 MCP servers...
 > [Gemini MCP] Based on last month's sales data, your top 3 products were:
 > 1. Widget Pro X - 1,234 units ($61,700)
@@ -1311,9 +1311,9 @@ src/main/java/com/cope/meteormcp/
 
 ### Why Two Gemini Commands Instead of Flags?
 
-**Alternative**: Single `/gemini` command with `--mcp` flag
+**Alternative**: Single `.gemini` command with `--mcp` flag
 
-**Chosen Approach**: Separate `/gemini` and `/gemini-mcp` commands
+**Chosen Approach**: Separate `.gemini` and `.gemini-mcp` commands
 
 **Rationale**:
 - **Simpler UX**: No need to remember flags
@@ -1388,12 +1388,12 @@ Allow users to create shorter aliases for frequently used commands:
 Store recent command executions for quick re-run:
 
 ```bash
-/gemini-history
+.gemini-history
 > Recent queries:
 > 1. "What's the weather in Tokyo?"
 > 2. "Schedule a meeting at 2pm"
 
-/gemini-rerun 1  # Re-execute query #1
+.gemini-rerun 1  # Re-execute query #1
 ```
 
 ---
@@ -1414,7 +1414,7 @@ Store command results for later use:
 
 ```bash
 /weather:get_forecast "London" --save weather_data
-/gemini-mcp "Analyze this weather data: ${weather_data}"
+.gemini-mcp "Analyze this weather data: ${weather_data}"
 ```
 
 ---
@@ -1433,7 +1433,7 @@ Add new section after Gemini integration:
 After connecting an MCP server, its tools become available as commands:
 
 #### Syntax
-/server_name:tool_name [arguments]
+.server_name:tool_name [arguments]
 
 #### Examples
 # Positional arguments
@@ -1448,10 +1448,10 @@ After connecting an MCP server, its tools become available as commands:
 ### Gemini Commands
 
 #### Simple Queries (No MCP Tools)
-/gemini "What is the capital of France?"
+.gemini "What is the capital of France?"
 
 #### MCP-Enhanced Queries (Automatic Tool Access)
-/gemini-mcp "What's the weather in Tokyo?"
+.gemini-mcp "What's the weather in Tokyo?"
 
 # Gemini automatically uses ALL connected MCP servers
 # to answer your query intelligently
@@ -1460,7 +1460,7 @@ After connecting an MCP server, its tools become available as commands:
 
 - **Dynamic Registration**: Commands appear/disappear as servers connect/disconnect
 - **Autocomplete**: Tab-completion for command names and parameters
-- **Help System**: `/command help` shows usage and parameter details
+- **Help System**: `.command help` shows usage and parameter details
 - **Async Execution**: Gemini commands run in background, don't block chat
 - **Error Handling**: Clear error messages with suggested fixes
 
@@ -1484,11 +1484,11 @@ Add to features section:
 - ✅ **MCP Server Management**: Connect, configure, and monitor MCP servers via GUI
 - ✅ **StarScript Integration**: Use MCP tools in expressions `{server.tool()}`
 - ✅ **Gemini AI Integration**: Intelligent prompts with `{gemini()}` and `{gemini_mcp()}`
-- ✅ **Command System**: Direct tool execution via `/server:tool` commands
-- ✅ **Gemini Commands**: Quick AI queries via `/gemini` and `/gemini-mcp`
+- ✅ **Command System**: Direct tool execution via `.server:tool` commands
+- ✅ **Gemini Commands**: Quick AI queries via `.gemini` and `.gemini-mcp`
 - ✅ **Dynamic Registration**: Commands auto-register when servers connect
 - ✅ **Autocomplete**: Tab-completion for commands and parameters
-- ✅ **Help System**: Inline help with `/command help`
+- ✅ **Help System**: Inline help with `.command help`
 
 ## Usage Examples
 
@@ -1502,10 +1502,10 @@ Add to features section:
 ### AI-Powered Queries
 ```bash
 # Simple query
-/gemini "Explain quantum physics"
+.gemini "Explain quantum physics"
 
 # Query with MCP tool access (automatic)
-/gemini-mcp "Check weather in London and schedule picnic if sunny"
+.gemini-mcp "Check weather in London and schedule picnic if sunny"
 ```
 
 ### StarScript Integration
@@ -1527,8 +1527,8 @@ This specification provides a complete blueprint for adding command system integ
 
 ✅ **Dynamic Command Registration**: Commands auto-register/unregister with server state
 ✅ **Flexible Argument Parsing**: Supports positional, named, and JSON arguments
-✅ **User-Friendly Syntax**: `/server:tool` pattern inspired by Minecraft conventions
-✅ **Gemini Command Access**: Both simple (`/gemini`) and enhanced (`/gemini-mcp`) modes
+✅ **User-Friendly Syntax**: `.server:tool` pattern inspired by Minecraft conventions
+✅ **Gemini Command Access**: Both simple (`.gemini`) and enhanced (`.gemini-mcp`) modes
 ✅ **Async Execution**: Non-blocking API calls for responsive UI
 ✅ **Help System**: Inline help with parameter details
 ✅ **Robust Error Handling**: Graceful failures with clear messages

--- a/src/main/java/com/cope/meteormcp/commands/GeminiCommand.java
+++ b/src/main/java/com/cope/meteormcp/commands/GeminiCommand.java
@@ -30,14 +30,14 @@ public class GeminiCommand extends Command {
         );
 
         builder.executes(context -> {
-            error("Prompt is required. Usage: /gemini \"prompt\"");
+            error("Prompt is required. Usage: .gemini \"prompt\"");
             return 0;
         });
     }
 
     int executeGemini(String prompt) {
         if (prompt == null || prompt.isBlank()) {
-            error("Prompt is required. Usage: /gemini \"prompt\"");
+            error("Prompt is required. Usage: .gemini \"prompt\"");
             return 0;
         }
 

--- a/src/main/java/com/cope/meteormcp/commands/GeminiMCPCommand.java
+++ b/src/main/java/com/cope/meteormcp/commands/GeminiMCPCommand.java
@@ -33,14 +33,14 @@ public class GeminiMCPCommand extends Command {
         );
 
         builder.executes(context -> {
-            error("Prompt is required. Usage: /gemini-mcp \"prompt\"");
+            error("Prompt is required. Usage: .gemini-mcp \"prompt\"");
             return 0;
         });
     }
 
     private int executeGeminiMCP(String prompt) {
         if (prompt == null || prompt.isBlank()) {
-            error("Prompt is required. Usage: /gemini-mcp \"prompt\"");
+            error("Prompt is required. Usage: .gemini-mcp \"prompt\"");
             return 0;
         }
 


### PR DESCRIPTION
Updated `README.md`, `GEMINI.md`, `CLAUDE.md`, and `ai_specs/COMMAND_INTEGRATION_SPEC.md` to reference `.gemini`, `.gemini-mcp`, and other commands with the correct prefix. 

Also updated error messages in `GeminiCommand.java` and `GeminiMCPCommand.java` to show the correct usage.